### PR TITLE
[zencoding/zxml] Replace xml.Token to xml.RawToken

### DIFF
--- a/zencoding/zxml/badgerfish_decode.go
+++ b/zencoding/zxml/badgerfish_decode.go
@@ -22,7 +22,7 @@ func (b *BadgerFish) Decode(decoder *xml.Decoder) (any, error) {
 	var token xml.Token
 	var err error
 	for {
-		if token, err = decoder.Token(); err != nil {
+		if token, err = decoder.RawToken(); err != nil {
 			if err != io.EOF {
 				return nil, &XMLError{Err: err, Cause: CauseXMLDecoder}
 			}
@@ -30,9 +30,9 @@ func (b *BadgerFish) Decode(decoder *xml.Decoder) (any, error) {
 		}
 		switch t := token.(type) {
 		case xml.StartElement:
-			content, err := b.decode(decoder, t, t.End(), nil)
+			content, err := b.decode(decoder, t, t.End())
 			if err != nil {
-				return nil, err
+				return nil, &XMLError{Err: err, Cause: CauseXMLDecoder}
 			}
 			objs = append(objs, content)
 		}
@@ -50,11 +50,9 @@ func (b *BadgerFish) Decode(decoder *xml.Decoder) (any, error) {
 	}
 }
 
-func (b *BadgerFish) decode(decoder *xml.Decoder, start xml.StartElement, end xml.EndElement, ns [][2]string) (map[string]any, error) {
-	// Append namespace of this element.
-	ns = append(ns, parseNamespace(start.Attr, ns)...)
+func (b *BadgerFish) decode(decoder *xml.Decoder, start xml.StartElement, end xml.EndElement) (map[string]any, error) {
 	// Convert attributes into map object.
-	attrs := b.attrsToMap(start.Attr, ns)
+	attrs := b.attrsToMap(start.Attr)
 
 	var text string
 	var keys []string
@@ -62,14 +60,10 @@ func (b *BadgerFish) decode(decoder *xml.Decoder, start xml.StartElement, end xm
 
 Loop:
 	for {
-		token, err := decoder.Token()
+		token, err := decoder.RawToken()
 		if err != nil {
-			if err != io.EOF {
-				err = &XMLError{Err: err, Cause: CauseXMLDecoder}
-			}
 			return nil, err
 		}
-
 		switch t := token.(type) {
 		case xml.CharData:
 			trimmed := bytes.TrimSpace(t)
@@ -82,7 +76,7 @@ Loop:
 				text += string(t)
 			}
 		case xml.StartElement:
-			content, err := b.decode(decoder, t, t.End(), ns)
+			content, err := b.decode(decoder, t, t.End())
 			if err != nil {
 				return nil, err
 			}
@@ -122,12 +116,12 @@ Loop:
 
 	if len(attrs) == 0 {
 		return map[string]any{
-			tokenName(start.Name, b.NamespaceSep, ns): b.emptyVal,
+			tokenName(start.Name, b.NamespaceSep): b.emptyVal,
 		}, nil
 	}
 
 	return map[string]any{
-		tokenName(start.Name, b.NamespaceSep, ns): attrs,
+		tokenName(start.Name, b.NamespaceSep): attrs,
 	}, nil
 }
 
@@ -140,7 +134,7 @@ Loop:
 //		"$": "http://abc.com/",
 //		"ns": "http://xyz.com/"
 //	}
-func (b *BadgerFish) attrsToMap(attrs []xml.Attr, ns [][2]string) map[string]any {
+func (b *BadgerFish) attrsToMap(attrs []xml.Attr) map[string]any {
 	m := make(map[string]any, 0)
 	for _, attr := range attrs {
 		name := attr.Name
@@ -148,14 +142,14 @@ func (b *BadgerFish) attrsToMap(attrs []xml.Attr, ns [][2]string) map[string]any
 		switch name.Space {
 		case "": // Format <elem foo="bar"> or <elem xmlns="http://abc.com/">
 			if name.Local != "xmlns" {
-				m[attrName(attr.Name, b.AttrPrefix, b.NamespaceSep, nil)] = attr.Value
+				m[attrName(attr.Name, b.AttrPrefix, b.NamespaceSep)] = attr.Value
 				continue
 			}
 			key = b.TextKey
 		case "xmlns": // Format <elem xmlns:foo="http://abc.com/">
 			key = name.Local
 		default: // Format <elem foo:bar="baz">
-			m[attrName(attr.Name, b.AttrPrefix, b.NamespaceSep, ns)] = attr.Value
+			m[attrName(attr.Name, b.AttrPrefix, b.NamespaceSep)] = attr.Value
 			continue
 		}
 		if v, ok := m[b.AttrPrefix+"xmlns"]; ok {

--- a/zencoding/zxml/rayfish_decode.go
+++ b/zencoding/zxml/rayfish_decode.go
@@ -22,7 +22,7 @@ func (r *RayFish) Decode(decoder *xml.Decoder) (any, error) {
 	var token xml.Token
 	var err error
 	for {
-		if token, err = decoder.Token(); err != nil {
+		if token, err = decoder.RawToken(); err != nil {
 			if err != io.EOF {
 				return nil, &XMLError{Err: err, Cause: CauseXMLDecoder}
 			}
@@ -30,9 +30,9 @@ func (r *RayFish) Decode(decoder *xml.Decoder) (any, error) {
 		}
 		switch t := token.(type) {
 		case xml.StartElement:
-			content, err := r.decode(decoder, t, t.End(), nil)
+			content, err := r.decode(decoder, t, t.End())
 			if err != nil {
-				return nil, err
+				return nil, &XMLError{Err: err, Cause: CauseXMLDecoder}
 			}
 			objs = append(objs, content)
 		}
@@ -50,15 +50,12 @@ func (r *RayFish) Decode(decoder *xml.Decoder) (any, error) {
 	}
 }
 
-func (r *RayFish) decode(decoder *xml.Decoder, start xml.StartElement, end xml.EndElement, ns [][2]string) (map[string]any, error) {
-	// Append namespace of this element.
-	ns = append(ns, parseNamespace(start.Attr, ns)...)
-
+func (r *RayFish) decode(decoder *xml.Decoder, start xml.StartElement, end xml.EndElement) (map[string]any, error) {
 	// Register attributes as children.
 	children := make([]map[string]any, 0, len(start.Attr))
 	for _, attr := range start.Attr {
 		children = append(children, map[string]any{
-			r.NameKey:     attrName(attr.Name, r.AttrPrefix, r.NamespaceSep, ns),
+			r.NameKey:     attrName(attr.Name, r.AttrPrefix, r.NamespaceSep),
 			r.TextKey:     attr.Value,
 			r.ChildrenKey: make([]map[string]any, 0), // Attribute has no child.
 		})
@@ -67,13 +64,13 @@ func (r *RayFish) decode(decoder *xml.Decoder, start xml.StartElement, end xml.E
 	var text string
 Loop:
 	for {
-		token, err := decoder.Token()
+		token, err := decoder.RawToken()
 		if err != nil {
-			return nil, &XMLError{Err: err, Cause: CauseXMLDecoder}
+			return nil, err
 		}
 		switch t := token.(type) {
 		case xml.StartElement:
-			content, err := r.decode(decoder, t, t.End(), ns)
+			content, err := r.decode(decoder, t, t.End())
 			if err != nil {
 				return nil, err
 			}
@@ -110,7 +107,7 @@ Loop:
 	}
 
 	return map[string]any{
-		r.NameKey:     tokenName(start.Name, r.NamespaceSep, ns),
+		r.NameKey:     tokenName(start.Name, r.NamespaceSep),
 		r.TextKey:     val,
 		r.ChildrenKey: children,
 	}, nil

--- a/zencoding/zxml/simple_decode.go
+++ b/zencoding/zxml/simple_decode.go
@@ -23,7 +23,7 @@ func (s *Simple) Decode(decoder *xml.Decoder) (any, error) {
 	var token xml.Token
 	var err error
 	for {
-		if token, err = decoder.Token(); err != nil {
+		if token, err = decoder.RawToken(); err != nil {
 			if err != io.EOF {
 				return nil, &XMLError{Err: err, Cause: CauseXMLDecoder}
 			}
@@ -31,9 +31,9 @@ func (s *Simple) Decode(decoder *xml.Decoder) (any, error) {
 		}
 		switch t := token.(type) {
 		case xml.StartElement:
-			content, err := s.parseContent(decoder, t, t.End(), nil)
+			content, err := s.parseContent(decoder, t, t.End())
 			if err != nil {
-				return nil, err
+				return nil, &XMLError{Err: err, Cause: CauseXMLDecoder}
 			}
 			objs = append(objs, content)
 		}
@@ -51,14 +51,11 @@ func (s *Simple) Decode(decoder *xml.Decoder) (any, error) {
 	}
 }
 
-func (s *Simple) parseContent(decoder *xml.Decoder, start xml.StartElement, end xml.EndElement, ns [][2]string) (map[string]any, error) {
-	// Append namespace of this element.
-	ns = append(ns, parseNamespace(start.Attr, ns)...)
-
+func (s *Simple) parseContent(decoder *xml.Decoder, start xml.StartElement, end xml.EndElement) (map[string]any, error) {
 	// Put attributes in the map.
 	attrs := make(map[string]any, len(start.Attr))
 	for _, attr := range start.Attr {
-		attrs[attrName(attr.Name, s.AttrPrefix, s.NamespaceSep, ns)] = attr.Value
+		attrs[attrName(attr.Name, s.AttrPrefix, s.NamespaceSep)] = attr.Value
 	}
 
 	var text string
@@ -67,14 +64,10 @@ func (s *Simple) parseContent(decoder *xml.Decoder, start xml.StartElement, end 
 
 Loop:
 	for {
-		token, err := decoder.Token()
+		token, err := decoder.RawToken()
 		if err != nil {
-			if err != io.EOF {
-				err = &XMLError{Err: err, Cause: CauseXMLDecoder}
-			}
 			return nil, err
 		}
-
 		switch t := token.(type) {
 		case xml.CharData:
 			trimmed := bytes.TrimSpace(t)
@@ -87,7 +80,7 @@ Loop:
 				text += string(t)
 			}
 		case xml.StartElement:
-			content, err := s.parseContent(decoder, t, t.End(), ns)
+			content, err := s.parseContent(decoder, t, t.End())
 			if err != nil {
 				return nil, err
 			}
@@ -127,7 +120,7 @@ Loop:
 		}
 		if s.PreferShort {
 			return map[string]any{
-				tokenName(start.Name, s.NamespaceSep, ns): val,
+				tokenName(start.Name, s.NamespaceSep): val,
 			}, nil
 		}
 	}
@@ -138,7 +131,7 @@ Loop:
 	}
 
 	return map[string]any{
-		tokenName(start.Name, s.NamespaceSep, ns): attrs,
+		tokenName(start.Name, s.NamespaceSep): attrs,
 	}, nil
 }
 

--- a/zencoding/zxml/tokenutil.go
+++ b/zencoding/zxml/tokenutil.go
@@ -60,32 +60,7 @@ func (e *XMLError) Is(err error) bool {
 	return false
 }
 
-// parseNamespace parses namespace from the given [encoding/xml.Attr].
-// Parsed namespaces are appended to the given ns with namespace aliases.
-// Appended array will becomes like follows.
-//
-//	xmlns="foo" --> {"xmlns", "foo"}
-//	xmlns:ns="foo" --> {"ns", "foo"}
-//	ns:bar="foo" --> {"bar", "foo"}
-//	bar="foo" --> Ignored
-func parseNamespace(attrs []xml.Attr, ns [][2]string) [][2]string {
-	for _, attr := range attrs {
-		name := attr.Name
-		switch name.Space {
-		case "":
-			if name.Local == "xmlns" {
-				ns = append(ns, [2]string{"xmlns", attr.Value})
-			}
-		case "xmlns":
-			ns = append(ns, [2]string{name.Local, attr.Value})
-		default:
-			ns = append(ns, [2]string{name.Local, attr.Value})
-		}
-	}
-	return ns
-}
-
-// attrName convert XML attributes token name to string.
+// attrName converts XML attribute token name to string.
 //
 // Examples (prefix="@", sep=":"):
 //
@@ -93,47 +68,17 @@ func parseNamespace(attrs []xml.Attr, ns [][2]string) [][2]string {
 //	ns:foo="bar" --> @ns:foo
 //	xmlns:foo="bar" --> @xmlns:foo
 //	xmlns="bar" --> @xmlns
-func attrName(name xml.Name, prefix, sep string, ns [][2]string) string {
+func attrName(name xml.Name, prefix, sep string) string {
 	if name.Space == "" {
 		return prefix + name.Local
-	}
-	for i := len(ns) - 1; i >= 0; i-- {
-		if name.Space == ns[i][1] {
-			return prefix + ns[i][0] + sep + name.Local
-		}
-	}
-	if name.Space == "http://www.w3.org/XML/1998/namespace" {
-		return prefix + "xml" + sep + name.Local
 	}
 	return prefix + name.Space + sep + name.Local
 }
 
-// tokenName converts token name given as [encoding/xml.Name] to string
-// with namespace consideration.
-// It returns string with <name> or <namespace><sep><name> format.
-// The <namespace> can be URI or alias name.
-// Namespace URI and corresponding alias name can be given by the
-// second argument ns.
-// For example [2]string{"xsd","http://www.w3.org/2001/XMLSchema"}
-// can be given as the ns.
-//
-// Why the ns should be given? The answer is the standard
-// [encoding/xml.Name.Space] always contains namespace value
-// which mostly URI. It does not have alias name information.
-func tokenName(name xml.Name, sep string, ns [][2]string) string {
+// tokenName returns name with namespace.
+func tokenName(name xml.Name, sep string) string {
 	if name.Space == "" {
 		return name.Local
-	}
-	for i := len(ns) - 1; i >= 0; i-- {
-		if name.Space == ns[i][1] {
-			if ns[i][0] == "xmlns" {
-				return name.Local // Do not add space for default namespace.
-			}
-			return ns[i][0] + sep + name.Local
-		}
-	}
-	if name.Space == "http://www.w3.org/XML/1998/namespace" {
-		return "xml" + sep + name.Local
 	}
 	return name.Space + sep + name.Local
 }

--- a/zencoding/zxml/tokenutil_test.go
+++ b/zencoding/zxml/tokenutil_test.go
@@ -73,61 +73,21 @@ func TestXMLError_Is(t *testing.T) {
 	})
 }
 
-func TestParseNamespace(t *testing.T) {
-	t.Parallel()
-	testCases := map[string]struct {
-		attrs []xml.Attr
-		ns    [][2]string
-	}{
-		"case01": {
-			attrs: []xml.Attr{{Name: xml.Name{Space: "", Local: "foo"}, Value: "test"}},
-			ns:    nil,
-		},
-		"case02": {
-			attrs: []xml.Attr{{Name: xml.Name{Space: "", Local: "xmlns"}, Value: "test"}},
-			ns:    [][2]string{{"xmlns", "test"}},
-		},
-		"case03": {
-			attrs: []xml.Attr{{Name: xml.Name{Space: "xmlns", Local: ""}, Value: "test"}},
-			ns:    [][2]string{{"", "test"}},
-		},
-		"case04": {
-			attrs: []xml.Attr{{Name: xml.Name{Space: "xmlns", Local: "ns"}, Value: "test"}},
-			ns:    [][2]string{{"ns", "test"}},
-		},
-		"case05": {
-			attrs: []xml.Attr{{Name: xml.Name{Space: "ns", Local: "foo"}, Value: "test"}},
-			ns:    [][2]string{{"foo", "test"}},
-		},
-	}
-	for name, tc := range testCases {
-		t.Run(name, func(t *testing.T) {
-			ns := parseNamespace(tc.attrs, nil)
-			ztesting.AssertEqual(t, "namespace not match", tc.ns, ns)
-		})
-	}
-}
-
 func TestAttrName(t *testing.T) {
 	t.Parallel()
 	testCases := map[string]struct {
 		name        xml.Name
 		prefix, sep string
-		ns          [][2]string
 		out         string
 	}{
-		"case01": {xml.Name{Space: "", Local: "foo"}, "@", ":", nil, "@foo"},
-		"case02": {xml.Name{Space: "ns", Local: "foo"}, "@", ":", nil, "@ns:foo"},
-		"case03": {xml.Name{Space: "ns", Local: "foo"}, "@", "_", nil, "@ns_foo"},
-		"case04": {xml.Name{Space: "alias", Local: "foo"}, "@", ":", [][2]string{{"xmlns", "alias"}}, "@xmlns:foo"},
-		"case05": {xml.Name{Space: "alias", Local: "foo"}, "@", ":", [][2]string{{"ns", "alias"}}, "@ns:foo"},
-		"case06": {xml.Name{Space: "alias", Local: "foo"}, "@", ":", [][2]string{{"ns1", "alias"}, {"ns2", "alias"}}, "@ns2:foo"},
-		"case07": {xml.Name{Space: "http://www.w3.org/XML/1998/namespace", Local: "foo"}, "@", ":", nil, "@xml:foo"},
-		"case08": {xml.Name{Space: "http://www.w3.org/XML/1998/namespace", Local: "foo"}, "@", "_", nil, "@xml_foo"},
+		"case01": {xml.Name{Space: "", Local: "foo"}, "@", ":", "@foo"},
+		"case02": {xml.Name{Space: "ns", Local: "foo"}, "@", ":", "@ns:foo"},
+		"case03": {xml.Name{Space: "ns", Local: "foo"}, "@", "_", "@ns_foo"},
+		"case04": {xml.Name{Space: "xmlns", Local: "foo"}, "@", ":", "@xmlns:foo"},
 	}
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
-			out := attrName(tc.name, tc.prefix, tc.sep, tc.ns)
+			out := attrName(tc.name, tc.prefix, tc.sep)
 			ztesting.AssertEqual(t, "result not match", tc.out, out)
 		})
 	}
@@ -138,21 +98,16 @@ func TestTokenName(t *testing.T) {
 	testCases := map[string]struct {
 		name xml.Name
 		sep  string
-		ns   [][2]string
 		out  string
 	}{
-		"case01": {xml.Name{Space: "", Local: "foo"}, ":", nil, "foo"},
-		"case02": {xml.Name{Space: "ns", Local: "foo"}, ":", nil, "ns:foo"},
-		"case03": {xml.Name{Space: "ns", Local: "foo"}, "_", nil, "ns_foo"},
-		"case04": {xml.Name{Space: "alias", Local: "foo"}, ":", [][2]string{{"xmlns", "alias"}}, "foo"},
-		"case05": {xml.Name{Space: "alias", Local: "foo"}, ":", [][2]string{{"ns", "alias"}}, "ns:foo"},
-		"case06": {xml.Name{Space: "alias", Local: "foo"}, ":", [][2]string{{"ns1", "alias"}, {"ns2", "alias"}}, "ns2:foo"},
-		"case07": {xml.Name{Space: "http://www.w3.org/XML/1998/namespace", Local: "foo"}, ":", nil, "xml:foo"},
-		"case08": {xml.Name{Space: "http://www.w3.org/XML/1998/namespace", Local: "foo"}, "_", nil, "xml_foo"},
+		"case01": {xml.Name{Space: "", Local: "foo"}, ":", "foo"},
+		"case02": {xml.Name{Space: "ns", Local: "foo"}, ":", "ns:foo"},
+		"case03": {xml.Name{Space: "ns", Local: "foo"}, "_", "ns_foo"},
+		"case04": {xml.Name{Space: "xmlns", Local: "foo"}, ":", "xmlns:foo"},
 	}
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
-			out := tokenName(tc.name, tc.sep, tc.ns)
+			out := tokenName(tc.name, tc.sep)
 			ztesting.AssertEqual(t, "result not match", tc.out, out)
 		})
 	}


### PR DESCRIPTION
## What type of PR is this?

- [ ] documentation
- [x] bug fix
- [ ] add/remove feature
- [ ] enhancement (add options, improve performance, refactoring, etc...)
- [ ] testing (add/remove/fix tests, etc...)
- [ ] release
- [ ] others

## Related issues

<!--
Fixes `#<issue number>` or `(paste link of issue)`
Closes `#<issue number>` or `(paste link of issue)`
-->

## Does this PR break user interface?

- [x] Yes <!-- Fill the release-note -->
- [ ] No

```release-note

```

## Description of this PR

When a element like `<elem baz:aaa="bbb" foo:baz="http://example.com" bar:baz="http://example.com" />` is input, the `aaa` attribute can have `foo` or `bar` because the xml.Token automatically resolves namespace to the URL.
It means the `baz:aaa="bbb"` is resolved as `http://example.com:aaa="bbb"` which make the original namespace cannot be identified.

So, this PR replaces the zml.Token() to xml.RawToken().

## Notes for reviewers
